### PR TITLE
React to testLogging.showStandardStreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,16 @@ Yes. You will need to switch to a suitable parallel theme though. This can be on
 `mocha-parallel`. The parallel themes are specially designed to work with a setting of
 [`maxParallelForks`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:maxParallelForks)
 greater than 1. They achieve this by sacrificing the ability to group tests and thus some readability is lost.
+
+### How are `testlogger` and `Test.testLogging` related?
+
+Until recently, they were unrelated. While this plugin's `testlogger` has many properties named identical to the ones in Gradle's
+`Test.testLogging`, to a large extent, they are kept isolated by design.
+
+However, as of this writing `testlogger.showStandardStreams` property has been made to react to `testLogging.showStandardStreams`
+property as long as one doesn't configure a value for `testlogger.showStandardStreams`. If a value is configured for
+`testlogger.showStandardStreams` (even if it is `false`), the plugin ignores `testLogging.showStandardStreams` altogether.
+
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ idea {
     }
 }
 
-
 test {
     testClassesDirs += sourceSets.functionalTest.output.classesDirs
     classpath += sourceSets.functionalTest.runtimeClasspath

--- a/src/test-functional/resources/test-marker.gradle
+++ b/src/test-functional/resources/test-marker.gradle
@@ -7,7 +7,7 @@ def combinedExtension
 afterEvaluate {
     testExtension = test.testlogger
     projectExtension = project.testlogger
-    combinedExtension = testExtension.combine(projectExtension)
+    combinedExtension = testExtension.undecorate().combine(projectExtension)
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
- React to testLogging.showStandardStreams
- Refactor `TestLoggerExtension` to have an `undecorate()` method that takes care of making the extension writable before properties are edited
- Apply overrides in a style similar to other methods that modify the properties
- Fixes #86 