### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ jobs:
                 key: v1-dependencies-{{ checksum "build.gradle" }}
             - run:
                 name: Run tests
-                command: GRADLE_OPTS="-Xms256m -Xmx2048m" ./gradlew build --no-daemon
+                command: GRADLE_OPTS="-Xms256m -Xmx2048m" ./gradlew build --no-daemon --scan
             - run:
                 name: Code coverage
-                command: GRADLE_OPTS="-Xms256m -Xmx1024m" ./gradlew jacocoTestReport coveralls --no-daemon
+                command: GRADLE_OPTS="-Xms256m -Xmx1024m" ./gradlew jacocoTestReport coveralls --no-daemon --scan
             - run:
                 name: Save reports
                 command: |
@@ -68,7 +68,7 @@ jobs:
             - run:
                 name: Publish plugin
                 command:
-                    GRADLE_OPTS="-Xms256m -Xmx1024m" ./gradlew clean publishPlugins --no-daemon
+                    GRADLE_OPTS="-Xms256m -Xmx1024m" ./gradlew clean publishPlugins --no-daemon --scan
                     -Pgradle.publish.key=${GRADLE_PUBLISH_KEY}
                     -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 }
 
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'maven-publish'
@@ -12,6 +13,11 @@ plugins {
     id 'jacoco'
     id 'com.gradle.plugin-publish' version '0.10.0'
     id 'com.github.kt3k.coveralls' version '2.8.2'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 def thisPlugin =

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,6 @@
 version=1.6.0
 group=com.adarshr
+
+org.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.