### PR TITLE
Add missing inputs to "functionalTest" task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ test {
 }
 
 task functionalTest(type: Test) {
+    inputs.dir "$projectDir/src/test-functional/resources"
     maxParallelForks = 2
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.test.runtimeClasspath + sourceSets.functionalTest.runtimeClasspath


### PR DESCRIPTION
This pull request fixes the specification of the Gradle task `functionalTest`.
This task depends on some test resources that are located in the `src/test-functional/resources` directory.

This commit considers this directory as inputs of this task so that tests are triggered whenever there are updates to any of the dependent test resources.