### PR TITLE
Added new theme that mimics maven surefire plugin

### DIFF
--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenParallelTheme.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenParallelTheme.groovy
@@ -1,0 +1,40 @@
+package com.adarshr.gradle.testlogger.theme
+
+import com.adarshr.gradle.testlogger.TestDescriptorWrapper
+import com.adarshr.gradle.testlogger.TestResultWrapper
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+
+import static com.adarshr.gradle.testlogger.theme.ThemeType.MAVEN_PARALLEL
+
+@CompileStatic
+@InheritConstructors
+class MavenParallelTheme extends MavenTheme {
+
+    ThemeType type = MAVEN_PARALLEL
+
+    @Override
+    protected String suiteTextInternal(TestDescriptorWrapper descriptor) {
+        ''
+    }
+
+    @Override
+    protected String testTextInternal(TestDescriptorWrapper descriptor, TestResultWrapper result) {
+        super.testTextInternal("[erase-ahead,bold]${descriptor.classDisplayName}[bold-off] ${descriptor.displayName}", descriptor, result)
+    }
+
+    @Override
+    String exceptionText(TestDescriptorWrapper descriptor, TestResultWrapper result) {
+        super.exceptionText(descriptor, result, 2)
+    }
+
+    @Override
+    protected String suiteStandardStreamTextInternal(String lines) {
+        super.standardStreamTextInternal(lines, 2)
+    }
+
+    @Override
+    protected String testStandardStreamTextInternal(String lines) {
+        super.standardStreamTextInternal(lines, 2)
+    }
+}

--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainParallelTheme.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainParallelTheme.groovy
@@ -1,0 +1,35 @@
+package com.adarshr.gradle.testlogger.theme
+
+import com.adarshr.gradle.testlogger.TestDescriptorWrapper
+import com.adarshr.gradle.testlogger.TestResultWrapper
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+
+import static com.adarshr.gradle.testlogger.theme.ThemeType.MAVEN_PLAIN_PARALLEL
+
+@CompileStatic
+@InheritConstructors
+class MavenPlainParallelTheme extends MavenPlainTheme {
+
+    ThemeType type = MAVEN_PLAIN_PARALLEL
+
+    @Override
+    protected String suiteTextInternal(TestDescriptorWrapper descriptor) {
+        ''
+    }
+
+    @Override
+    protected String testTextInternal(TestDescriptorWrapper descriptor, TestResultWrapper result) {
+        super.testTextInternal("${descriptor.classDisplayName} ${descriptor.displayName} ${RESULT_TYPE_MAPPING[result.resultType]}", descriptor, result)
+    }
+
+    @Override
+    protected String suiteStandardStreamTextInternal(String lines) {
+        super.standardStreamTextInternal(lines, 2)
+    }
+
+    @Override
+    protected String testStandardStreamTextInternal(String lines) {
+        super.standardStreamTextInternal(lines, 2)
+    }
+}

--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainTheme.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainTheme.groovy
@@ -1,0 +1,34 @@
+package com.adarshr.gradle.testlogger.theme
+
+import com.adarshr.gradle.testlogger.TestDescriptorWrapper
+import com.adarshr.gradle.testlogger.TestResultWrapper
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+
+import static com.adarshr.gradle.testlogger.theme.ThemeType.MAVEN
+import static com.adarshr.gradle.testlogger.theme.ThemeType.MAVEN_PLAIN
+import static com.adarshr.gradle.testlogger.theme.ThemeType.PLAIN
+import static com.adarshr.gradle.testlogger.util.RendererUtils.escape
+import static java.lang.System.lineSeparator
+import static org.gradle.api.tasks.testing.TestResult.ResultType.*
+
+@CompileStatic
+@InheritConstructors
+class MavenPlainTheme extends PlainTheme {
+
+    ThemeType type = MAVEN_PLAIN
+
+    @Override
+    String summaryText(TestDescriptorWrapper descriptor, TestResultWrapper result) {
+        if (!extension.showSummary) {
+            return ''
+        }
+        def line = new StringBuilder()
+
+        line << "Summary:${lineSeparator()}${lineSeparator()}"
+
+        line << " Tests run: ${result.testCount}, " +
+            "Failures: ${result.failedTestCount}, Skipped: ${result.skippedTestCount}, " +
+            "Time elapsed: ${result.duration}"
+    }
+}

--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenTheme.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/MavenTheme.groovy
@@ -1,0 +1,39 @@
+package com.adarshr.gradle.testlogger.theme
+
+import com.adarshr.gradle.testlogger.TestDescriptorWrapper
+import com.adarshr.gradle.testlogger.TestResultWrapper
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+
+import static com.adarshr.gradle.testlogger.theme.ThemeType.MAVEN
+import static java.lang.System.lineSeparator
+
+@CompileStatic
+@InheritConstructors
+class MavenTheme extends StandardTheme {
+
+    ThemeType type = MAVEN
+
+    @Override
+    String summaryText(TestDescriptorWrapper descriptor, TestResultWrapper result) {
+        if (!extension.showSummary) {
+            return ''
+        }
+
+        String colour = 'green';
+
+        if (result.failedTestCount > 0) {
+            colour = 'red';
+        } else if (result.skippedTestCount > 0) {
+            colour = 'yellow';
+        }
+
+        def line = new StringBuilder()
+
+        line << "[erase-ahead,default]Summary:${lineSeparator()}${lineSeparator()}"
+
+        line << "[bold,${colour}] Tests run: ${result.testCount}, " +
+            "Failures: ${result.failedTestCount}, Skipped: ${result.skippedTestCount}, " +
+            "Time elapsed: ${result.duration}[/]"
+    }
+}

--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/ThemeType.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/ThemeType.groovy
@@ -7,12 +7,16 @@ import org.gradle.api.GradleException
 enum ThemeType {
     //@formatter:off
     //                  name                    parallel    themeClass              parallelFallback
-    PLAIN(              'plain',                false,      PlainTheme,             'plain-parallel'),
-    PLAIN_PARALLEL(     'plain-parallel',       true,       PlainParallelTheme,     null),
-    STANDARD(           'standard',             false,      StandardTheme,          'standard-parallel'),
-    STANDARD_PARALLEL(  'standard-parallel',    true,       StandardParallelTheme,  null),
-    MOCHA(              'mocha',                false,      MochaTheme,             'mocha-parallel'),
-    MOCHA_PARALLEL(     'mocha-parallel',       true,       MochaParallelTheme,     null)
+    PLAIN(               'plain',                false,      PlainTheme,             'plain-parallel'),
+    PLAIN_PARALLEL(      'plain-parallel',       true,       PlainParallelTheme,     null),
+    STANDARD(            'standard',             false,      StandardTheme,          'standard-parallel'),
+    STANDARD_PARALLEL(   'standard-parallel',    true,       StandardParallelTheme,  null),
+    MOCHA(               'mocha',                false,      MochaTheme,             'mocha-parallel'),
+    MOCHA_PARALLEL(      'mocha-parallel',       true,       MochaParallelTheme,     null),
+    MAVEN(               'maven',                false,      MavenTheme,             'maven-parallel'),
+    MAVEN_PARALLEL(      'maven-parallel',       true,       MavenParallelTheme,     null),
+    MAVEN_PLAIN(         'maven-plain',          false,      MavenPlainTheme,        'maven-plain-parallel'),
+    MAVEN_PLAIN_PARALLEL('maven-plain-parallel', true,       MavenPlainParallelTheme,null)
     //@formatter:on
 
     final String name

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenParallelThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenParallelThemeSpec.groovy
@@ -1,0 +1,90 @@
+package com.adarshr.gradle.testlogger.theme
+
+import spock.lang.Unroll
+
+import static java.lang.System.lineSeparator
+import static org.gradle.api.tasks.testing.TestResult.ResultType.*
+
+class MavenParallelThemeSpec extends BaseThemeSpec {
+
+    // right at the top to minimise line number changes
+    private static AssertionError getException() {
+        new AssertionError('This is wrong')
+    }
+
+    private static final int LINE_NUMBER = exception.stackTrace.find { it.className == owner.name }.lineNumber
+
+    Theme theme
+
+    def setup() {
+        theme = new MavenParallelTheme(testLoggerExtensionMock)
+    }
+
+    def "before suite"() {
+        expect:
+            !theme.suiteText(testDescriptorMock, testResultMock)
+    }
+
+    @Unroll
+    def "after test with result type #resultType"() {
+        given:
+            testResultMock.resultType >> resultType
+            testDescriptorMock.classDisplayName >> 'ClassName'
+            testDescriptorMock.displayName >> 'test name'
+        when:
+            def actual = theme.testText(testDescriptorMock, testResultMock)
+        then:
+            actual == expected
+        where:
+            resultType | expected
+            SUCCESS    | '[erase-ahead,bold]ClassName[bold-off] test name[green] PASSED[/]'
+            FAILURE    | '[erase-ahead,bold]ClassName[bold-off] test name[red] FAILED[/]'
+            SKIPPED    | '[erase-ahead,bold]ClassName[bold-off] test name[yellow] SKIPPED[/]'
+    }
+
+    def "exception text when showExceptions is true"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testLoggerExtensionMock.showStackTraces >> true
+            testLoggerExtensionMock.showCauses >> true
+            theme = new MavenParallelTheme(testLoggerExtensionMock)
+        and:
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> exception
+            testDescriptorMock.displayName >> 'floppy test'
+            testDescriptorMock.className >> this.class.name
+        expect:
+            theme.exceptionText(testDescriptorMock, testResultMock) ==
+                """|[red]
+                   |
+                   |  java.lang.AssertionError: This is wrong
+                   |      at com.adarshr.gradle.testlogger.theme.MavenParallelThemeSpec.getException(MavenParallelThemeSpec.groovy:${
+                    LINE_NUMBER
+                })
+                   |""".stripMargin().replace('\n', lineSeparator())
+    }
+
+    def "standard stream text"() {
+        given:
+            testLoggerExtensionMock.showStandardStreams >> true
+            theme = new MavenParallelTheme(testLoggerExtensionMock)
+        expect:
+            theme.testStandardStreamText(streamLines, testResultMock) ==
+                '''|[default]
+                   |  Hello
+                   |  World \\[brackets\\] \u001B\\[0mANSI[/]
+                   |'''.stripMargin().replace('\n', lineSeparator())
+    }
+
+    def "suite stream text"() {
+        given:
+            testLoggerExtensionMock.showStandardStreams >> true
+            theme = new MavenParallelTheme(testLoggerExtensionMock)
+        expect:
+            theme.suiteStandardStreamText(streamLines, testResultMock) ==
+                '''|[default]
+                   |  Hello
+                   |  World \\[brackets\\] \u001B\\[0mANSI[/]
+                   |'''.stripMargin().replace('\n', lineSeparator())
+    }
+}

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainParallelThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainParallelThemeSpec.groovy
@@ -1,0 +1,90 @@
+package com.adarshr.gradle.testlogger.theme
+
+import spock.lang.Unroll
+
+import static java.lang.System.lineSeparator
+import static org.gradle.api.tasks.testing.TestResult.ResultType.*
+
+class MavenPlainParallelThemeSpec extends BaseThemeSpec {
+
+    // right at the top to minimise line number changes
+    private static AssertionError getException() {
+        new AssertionError('This is wrong')
+    }
+
+    private static final int LINE_NUMBER = exception.stackTrace.find { it.className == owner.name }.lineNumber
+
+    Theme theme
+
+    def setup() {
+        theme = new MavenPlainParallelTheme(testLoggerExtensionMock)
+    }
+
+    def "before suite"() {
+        expect:
+            !theme.suiteText(testDescriptorMock, testResultMock)
+    }
+
+    @Unroll
+    def "after test with result type #resultType"() {
+        given:
+            testResultMock.resultType >> resultType
+            testDescriptorMock.classDisplayName >> 'ClassName'
+            testDescriptorMock.displayName >> 'test name'
+        when:
+            def actual = theme.testText(testDescriptorMock, testResultMock)
+        then:
+            actual == expected
+        where:
+            resultType | expected
+            SUCCESS    | 'ClassName test name PASSED'
+            FAILURE    | 'ClassName test name FAILED'
+            SKIPPED    | 'ClassName test name SKIPPED'
+    }
+
+    def "exception text when showExceptions is true"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testLoggerExtensionMock.showStackTraces >> true
+            testLoggerExtensionMock.showCauses >> true
+            theme = new MavenPlainParallelTheme(testLoggerExtensionMock)
+        and:
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> exception
+            testDescriptorMock.displayName >> 'floppy test'
+            testDescriptorMock.className >> this.class.name
+        expect:
+            theme.exceptionText(testDescriptorMock, testResultMock) ==
+                """|
+                   |
+                   |  java.lang.AssertionError: This is wrong
+                   |      at com.adarshr.gradle.testlogger.theme.MavenPlainParallelThemeSpec.getException(MavenPlainParallelThemeSpec.groovy:${LINE_NUMBER})
+                   |""".stripMargin().replace('\n', lineSeparator())
+    }
+
+    def "standard stream text"() {
+        given:
+            testLoggerExtensionMock.showStandardStreams >> true
+            theme = new MavenPlainParallelTheme(testLoggerExtensionMock)
+            testResultMock.resultType >> SUCCESS
+        expect:
+            theme.testStandardStreamText(streamLines, testResultMock) ==
+                '''|
+                   |  Hello
+                   |  World \\[brackets\\] \u001B\\[0mANSI
+                   |'''.stripMargin().replace('\n', lineSeparator())
+    }
+
+    def "suite stream text"() {
+        given:
+            testLoggerExtensionMock.showStandardStreams >> true
+            theme = new MavenPlainParallelTheme(testLoggerExtensionMock)
+            testResultMock.resultType >> SUCCESS
+        expect:
+            theme.suiteStandardStreamText(streamLines, testResultMock) ==
+                '''|
+                   |  Hello
+                   |  World \\[brackets\\] \u001B\\[0mANSI
+                   |'''.stripMargin().replace('\n', lineSeparator())
+    }
+}

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenPlainThemeSpec.groovy
@@ -1,0 +1,47 @@
+package com.adarshr.gradle.testlogger.theme
+
+import spock.lang.Unroll
+
+import static java.lang.System.lineSeparator
+import static org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE
+import static org.gradle.api.tasks.testing.TestResult.ResultType.SUCCESS
+
+class MavenPlainThemeSpec extends BaseThemeSpec {
+
+    private static final String SUMMARY_LABEL = "Summary:${lineSeparator()}${lineSeparator()}"
+    
+    Theme theme
+
+    def setup() {
+        theme = new MavenPlainTheme(testLoggerExtensionMock)
+    }
+
+    @Unroll
+    def "summary text given #success success, #failure failed and #skipped skipped tests"() {
+        given:
+            testLoggerExtensionMock.showSummary >> true
+            testResultMock.successfulTestCount >> success
+            testResultMock.failedTestCount >> failure
+            testResultMock.skippedTestCount >> skipped
+            testResultMock.testCount >> success + failure + skipped
+            testResultMock.duration >> '10s'
+            testResultMock.resultType >> (failure ? FAILURE : SUCCESS) // what Gradle would do
+        and:
+            theme = new MavenPlainTheme(testLoggerExtensionMock)
+        when:
+            def actual = theme.summaryText(testDescriptorMock, testResultMock)
+        then:
+            actual == summaryText
+        where:
+            summaryText                                                                  | success | failure | skipped
+            "${SUMMARY_LABEL} Tests run: 10, Failures: 0, Skipped: 0, Time elapsed: 10s" | 10      | 0       | 0
+            "${SUMMARY_LABEL} Tests run: 7, Failures: 0, Skipped: 2, Time elapsed: 10s"  | 5       | 0       | 2
+            "${SUMMARY_LABEL} Tests run: 8, Failures: 3, Skipped: 0, Time elapsed: 10s"  | 5       | 3       | 0
+            "${SUMMARY_LABEL} Tests run: 10, Failures: 3, Skipped: 2, Time elapsed: 10s" | 5       | 3       | 2
+    }
+
+    def "summary when showSummary is false"() {
+        expect:
+            !theme.summaryText(testDescriptorMock, testResultMock)
+    }
+}

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/MavenThemeSpec.groovy
@@ -1,0 +1,47 @@
+package com.adarshr.gradle.testlogger.theme
+
+import spock.lang.Unroll
+
+import static java.lang.System.lineSeparator
+import static org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE
+import static org.gradle.api.tasks.testing.TestResult.ResultType.SUCCESS
+
+class MavenThemeSpec extends BaseThemeSpec {
+
+    private static final String SUMMARY_LABEL = "[erase-ahead,default]Summary:${lineSeparator()}${lineSeparator()}"
+    
+    Theme theme
+
+    def setup() {
+        theme = new MavenTheme(testLoggerExtensionMock)
+    }
+
+    @Unroll
+    def "summary text given #success success, #failure failed and #skipped skipped tests"() {
+        given:
+            testLoggerExtensionMock.showSummary >> true
+            testResultMock.successfulTestCount >> success
+            testResultMock.failedTestCount >> failure
+            testResultMock.skippedTestCount >> skipped
+            testResultMock.testCount >> success + failure + skipped
+            testResultMock.duration >> '10s'
+            testResultMock.resultType >> (failure ? FAILURE : SUCCESS) // what Gradle would do
+        and:
+            theme = new MavenTheme(testLoggerExtensionMock)
+        when:
+            def actual = theme.summaryText(testDescriptorMock, testResultMock)
+        then:
+            actual == summaryText
+        where:
+            summaryText                                                                                 | success | failure | skipped
+            "${SUMMARY_LABEL}[bold,green] Tests run: 10, Failures: 0, Skipped: 0, Time elapsed: 10s[/]" | 10      | 0       | 0
+            "${SUMMARY_LABEL}[bold,yellow] Tests run: 7, Failures: 0, Skipped: 2, Time elapsed: 10s[/]" | 5       | 0       | 2
+            "${SUMMARY_LABEL}[bold,red] Tests run: 8, Failures: 3, Skipped: 0, Time elapsed: 10s[/]"    | 5       | 3       | 0
+            "${SUMMARY_LABEL}[bold,red] Tests run: 10, Failures: 3, Skipped: 2, Time elapsed: 10s[/]"   | 5       | 3       | 2
+    }
+
+    def "summary when showSummary is false"() {
+        expect:
+            !theme.summaryText(testDescriptorMock, testResultMock)
+    }
+}

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/ThemeTypeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/ThemeTypeSpec.groovy
@@ -4,7 +4,6 @@ import org.gradle.api.GradleException
 import spock.lang.Specification
 import spock.lang.Unroll
 
-
 class ThemeTypeSpec extends Specification {
 
     @Unroll
@@ -12,13 +11,17 @@ class ThemeTypeSpec extends Specification {
         expect:
             ThemeType.fromName(name) == themeType
         where:
-            name                | themeType
-            'plain'             | ThemeType.PLAIN
-            'plain-parallel'    | ThemeType.PLAIN_PARALLEL
-            'standard'          | ThemeType.STANDARD
-            'standard-parallel' | ThemeType.STANDARD_PARALLEL
-            'mocha'             | ThemeType.MOCHA
-            'mocha-parallel'    | ThemeType.MOCHA_PARALLEL
+            name                   | themeType
+            'plain'                | ThemeType.PLAIN
+            'plain-parallel'       | ThemeType.PLAIN_PARALLEL
+            'standard'             | ThemeType.STANDARD
+            'standard-parallel'    | ThemeType.STANDARD_PARALLEL
+            'mocha'                | ThemeType.MOCHA
+            'mocha-parallel'       | ThemeType.MOCHA_PARALLEL
+            'maven'                | ThemeType.MAVEN
+            'maven-parallel'       | ThemeType.MAVEN_PARALLEL
+            'maven-plain'          | ThemeType.MAVEN_PLAIN
+            'maven-plain-parallel' | ThemeType.MAVEN_PLAIN_PARALLEL
     }
 
     def "fromName throws exception if unknown theme name is specified"() {
@@ -30,12 +33,14 @@ class ThemeTypeSpec extends Specification {
 
     def "get all theme names"() {
         expect:
-            ThemeType.allThemeNames == "'plain', 'plain-parallel', 'standard', 'standard-parallel', 'mocha', 'mocha-parallel'"
+            ThemeType.allThemeNames == "'plain', 'plain-parallel', 'standard', 'standard-parallel', " +
+                "'mocha', 'mocha-parallel', 'maven', 'maven-parallel', 'maven-plain', 'maven-plain-parallel'"
     }
 
     def "get parallel theme names"() {
         expect:
-            ThemeType.parallelThemeNames == "'plain-parallel', 'standard-parallel', 'mocha-parallel'"
+            ThemeType.parallelThemeNames == "'plain-parallel', " +
+                "'standard-parallel', 'mocha-parallel', 'maven-parallel', 'maven-plain-parallel'"
     }
 
     @Unroll


### PR DESCRIPTION
Since the plugin does not provide a way to define the test summary I've
added new themes (maven and maven-plain) and that inherit from
standard and plain themes repsectively but override summaryText to format it the way
maven-surefire(and failsafe)-plugin used to do it maven. I've also
updated unit tests so their passing again and added some new tests for
new classes.

Differences with maven plugin:
- added the Time Elapsed to "Test Run: " line
- changed "Results:" to "Summary:" as Gradle build outputs errors before
Summary (maven includes errors in Results section).

Ideally the plugin provide a way to customize how the summary text looks like, but this will be harder to implement in a generic way that would satisfy everyone needs.