### PR TITLE
Upgrade plugin publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'maven-publish'
     id 'idea'
     id 'jacoco'
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'com.github.kt3k.coveralls' version '2.9.0'
 }
 


### PR DESCRIPTION
To fix the below error:

```
Execution failed for task ':publishPlugins'.
> Failed to post to server.
  Server responded with:
  This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability.
  Please update to the latest version of the com.gradle.plugin-publish plugin found here:
     https://plugins.gradle.org/plugin/com.gradle.plugin-publish
  You can read more about this vulnerability here:
     https://blog.gradle.org/plugin-portal-update
```