### PR TITLE
Fix for NPE when the exception in the TestResult is null.

### DIFF
--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/AbstractTheme.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/AbstractTheme.groovy
@@ -53,7 +53,7 @@ abstract class AbstractTheme implements Theme {
     protected String exceptionText(TestDescriptorWrapper descriptor, TestResultWrapper result, int indent) {
         def line = new StringBuilder()
 
-        if (!extension.showExceptions) {
+        if (!extension.showExceptions || result.exception == null) {
             return line
         }
 

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/MochaParallelThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/MochaParallelThemeSpec.groovy
@@ -105,6 +105,16 @@ class MochaParallelThemeSpec extends BaseThemeSpec {
             !theme.exceptionText(testDescriptorMock, testResultMock)
     }
 
+    def "exception text when showExceptions is true but exception is null"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> null
+            testDescriptorMock.displayName >> 'exception is null test'
+        expect:
+            !theme.exceptionText(testDescriptorMock, testResultMock)
+    }
+
     @Unroll
     def "show duration if slowThreshold is exceeded for resultType #resultType"() {
         given:

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/MochaThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/MochaThemeSpec.groovy
@@ -108,6 +108,16 @@ class MochaThemeSpec extends BaseThemeSpec {
             !theme.exceptionText(testDescriptorMock, testResultMock)
     }
 
+    def "exception text when showExceptions is true but exception is null"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> null
+            testDescriptorMock.displayName >> 'exception is null test'
+        expect:
+            !theme.exceptionText(testDescriptorMock, testResultMock)
+    }
+
     @Unroll
     def "show duration if slowThreshold is exceeded for resultType #resultType"() {
         given:

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/PlainParallelThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/PlainParallelThemeSpec.groovy
@@ -95,6 +95,17 @@ class PlainParallelThemeSpec extends BaseThemeSpec {
             !theme.exceptionText(testDescriptorMock, testResultMock)
     }
 
+
+    def "exception text when showExceptions is true but exception is null"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> null
+            testDescriptorMock.displayName >> 'exception is null test'
+        expect:
+            !theme.exceptionText(testDescriptorMock, testResultMock)
+    }
+
     def "show duration if slowThreshold is exceeded"() {
         given:
             testResultMock.tooSlow >> true

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/PlainThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/PlainThemeSpec.groovy
@@ -97,6 +97,17 @@ class PlainThemeSpec extends BaseThemeSpec {
             !theme.exceptionText(testDescriptorMock, testResultMock)
     }
 
+
+    def "exception text when showExceptions is true but exception is null"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> null
+            testDescriptorMock.displayName >> 'exception is null test'
+        expect:
+            !theme.exceptionText(testDescriptorMock, testResultMock)
+    }
+
     def "show duration if slowThreshold is exceeded"() {
         given:
             testResultMock.duration >> '10s'

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/StandardParallelThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/StandardParallelThemeSpec.groovy
@@ -99,6 +99,17 @@ class StandardParallelThemeSpec extends BaseThemeSpec {
             !theme.exceptionText(testDescriptorMock, testResultMock)
     }
 
+
+    def "exception text when showExceptions is true but exception is null"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> null
+            testDescriptorMock.displayName >> 'exception is null test'
+        expect:
+            !theme.exceptionText(testDescriptorMock, testResultMock)
+    }
+
     @Unroll
     def "show duration if slowThreshold is exceeded for resultType #resultType"() {
         given:

--- a/src/test/groovy/com/adarshr/gradle/testlogger/theme/StandardThemeSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/theme/StandardThemeSpec.groovy
@@ -97,6 +97,16 @@ class StandardThemeSpec extends BaseThemeSpec {
             !theme.exceptionText(testDescriptorMock, testResultMock)
     }
 
+    def "exception text when showExceptions is true but exception is null"() {
+        given:
+            testLoggerExtensionMock.showExceptions >> true
+            testResultMock.resultType >> FAILURE
+            testResultMock.exception >> null
+            testDescriptorMock.displayName >> 'exception is null test'
+        expect:
+            !theme.exceptionText(testDescriptorMock, testResultMock)
+    }
+
     @Unroll
     def "show duration if slowThreshold is exceeded for resultType #resultType"() {
         given:


### PR DESCRIPTION
This happens when an exception is thrown in the application being tested but isn't added to the gradle TestResult object (as it is a nullable field), which in turn causes no report to be generated; which makes it very hard to see what the actual error in the application is.