### PR TITLE
Allowing finding of AbstractTestTask instead of only Test

### DIFF
--- a/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerExtension.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerExtension.groovy
@@ -8,7 +8,7 @@ import org.gradle.api.logging.LogLevel
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
-import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 import static com.adarshr.gradle.testlogger.theme.ThemeType.STANDARD
@@ -42,9 +42,9 @@ class TestLoggerExtension extends TestLoggerExtensionProperties {
     private final SetProperty<TestLogEvent> originalTestLoggingEvents
     private final TestLoggerExtension projectExtension
     private final ProviderFactory providers
-    private final Test test
+    private final AbstractTestTask test
 
-    TestLoggerExtension(Project project, Test test = null) {
+    TestLoggerExtension(Project project, AbstractTestTask test = null) {
         this.theme = project.objects.property(ThemeType)
         this.logLevel = project.objects.property(LogLevel)
         this.showExceptions = project.objects.property(Boolean)

--- a/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerPlugin.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerPlugin.groovy
@@ -4,7 +4,7 @@ import com.adarshr.gradle.testlogger.logger.TestLoggerWrapper
 import groovy.transform.CompileStatic
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.AbstractTestTask
 
 @CompileStatic
 class TestLoggerPlugin implements Plugin<Project> {
@@ -15,7 +15,7 @@ class TestLoggerPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.extensions.create(EXTENSION_NAME, TestLoggerExtension, project)
 
-        project.tasks.withType(Test).configureEach { Test test ->
+        project.tasks.withType(AbstractTestTask).configureEach { AbstractTestTask test ->
             def testExtension = test.extensions.create(EXTENSION_NAME, TestLoggerExtension, project, test)
 
             testExtension.originalTestLoggingEvents = test.testLogging.events

--- a/src/main/groovy/com/adarshr/gradle/testlogger/logger/TestLoggerWrapper.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/logger/TestLoggerWrapper.groovy
@@ -5,18 +5,18 @@ import com.adarshr.gradle.testlogger.theme.Theme
 import com.adarshr.gradle.testlogger.theme.ThemeFactory
 import groovy.transform.CompileStatic
 import org.gradle.StartParameter
-import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.AbstractTestTask
 
 @CompileStatic
 class TestLoggerWrapper implements TestLogger {
 
     private final StartParameter startParameter
-    private final Test test
+    private final AbstractTestTask test
     private final TestLoggerExtension testLoggerExtension
 
     private TestLogger testLoggerDelegate
 
-    TestLoggerWrapper(StartParameter startParameter, Test test, TestLoggerExtension testLoggerExtension) {
+    TestLoggerWrapper(StartParameter startParameter, AbstractTestTask test, TestLoggerExtension testLoggerExtension) {
         this.startParameter = startParameter
         this.test = test
         this.testLoggerExtension = testLoggerExtension

--- a/src/main/groovy/com/adarshr/gradle/testlogger/theme/ThemeFactory.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/theme/ThemeFactory.groovy
@@ -3,6 +3,7 @@ package com.adarshr.gradle.testlogger.theme
 import com.adarshr.gradle.testlogger.TestLoggerExtension
 import groovy.transform.CompileStatic
 import org.gradle.StartParameter
+import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.testng.TestNGOptions
 
@@ -13,18 +14,18 @@ import static org.gradle.api.logging.configuration.ConsoleOutput.Plain
 @CompileStatic
 class ThemeFactory {
 
-    static Theme getTheme(StartParameter startParameter, Test test, TestLoggerExtension extension) {
+    static Theme getTheme(StartParameter startParameter, AbstractTestTask test, TestLoggerExtension extension) {
         resolveThemeType(startParameter, test, extension).themeClass.newInstance(extension)
     }
 
-    private static ThemeType resolveThemeType(StartParameter startParameter, Test test, TestLoggerExtension extension) {
+    private static ThemeType resolveThemeType(StartParameter startParameter, AbstractTestTask test, TestLoggerExtension extension) {
         ThemeType themeType = extension.theme
 
         if (startParameter.consoleOutput == Plain) {
             themeType = PLAIN
         }
 
-        if (isParallelMode(test) && !themeType.parallel) {
+        if (test instanceof Test && isParallelMode(test) && !themeType.parallel) {
             themeType = fromName(themeType.parallelFallback)
         }
 


### PR DESCRIPTION
Kind of a lark, but I made this change to see if I could get this plugin to work with the kotlin multiplatform tests... and it worked!

Figured it'd be worth sharing in case it sparks some joy.