### PR TITLE
feat: Allow skipping distribution details in parallel mode

### DIFF
--- a/src/main/groovy/com/adarshr/gradle/testlogger/TestDescriptorWrapper.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/TestDescriptorWrapper.groovy
@@ -22,7 +22,22 @@ class TestDescriptorWrapper {
         this.testLoggerExtension = testLoggerExtension
         this.depth = ancestors.size()
         this.ancestors = ancestors
-        this.trail = ancestors.collect { it.displayName }.join(' > ')
+        this.trail = buildTrail(ancestors, testLoggerExtension)
+    }
+
+    private static String buildTrail(List<TestDescriptorWrapper> ancestors, TestLoggerExtension extension) {
+        var filteredAncestors = ancestors
+        if (!extension.showDistributionDetails) {
+            filteredAncestors = ancestors.findAll { ancestor ->
+                !isDistributionAncestor(ancestor.displayName)
+            }
+        }
+        return filteredAncestors.collect { it.displayName }.join(' > ')
+    }
+
+    private static boolean isDistributionAncestor(String displayName) {
+        return displayName.startsWith('Distributed Test Run') ||
+               displayName.contains('Partition') && displayName.contains('session')
     }
 
     @CompileDynamic

--- a/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerExtension.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerExtension.groovy
@@ -38,6 +38,7 @@ class TestLoggerExtension extends TestLoggerExtensionProperties {
     private final Property<Boolean> showFailed
     private final Property<Boolean> showSimpleNames
     private final Property<Boolean> showOnlySlow
+    private final Property<Boolean> showDistributionDetails
 
     private final SetProperty<TestLogEvent> originalTestLoggingEvents
     private final TestLoggerExtension projectExtension
@@ -62,6 +63,7 @@ class TestLoggerExtension extends TestLoggerExtensionProperties {
         this.showFailed = project.objects.property(Boolean)
         this.showSimpleNames = project.objects.property(Boolean)
         this.showOnlySlow = project.objects.property(Boolean)
+        this.showDistributionDetails = project.objects.property(Boolean)
 
         this.originalTestLoggingEvents = project.objects.setProperty(TestLogEvent)
         this.projectExtension = project.extensions.findByType(TestLoggerExtension)
@@ -221,6 +223,14 @@ class TestLoggerExtension extends TestLoggerExtensionProperties {
             .getOrElse(false)
     }
 
+    Boolean getShowDistributionDetails() {
+        providers.systemProperty('testlogger.showDistributionDetails')
+            .map { Boolean.valueOf(it) }
+            .orElse(showDistributionDetails)
+            .orElse(projectExtension.@showDistributionDetails)
+            .getOrElse(true)
+    }
+
     @PackageScope
     void setOriginalTestLoggingEvents(Set<TestLogEvent> events) {
         this.originalTestLoggingEvents.value(events).finalizeValue()
@@ -326,5 +336,10 @@ class TestLoggerExtension extends TestLoggerExtensionProperties {
     @Override
     void setShowOnlySlow(Boolean showOnlySlow) {
         this.showOnlySlow.set(showOnlySlow)
+    }
+
+    @Override
+    void setShowDistributionDetails(Boolean showDistributionDetails) {
+        this.showDistributionDetails.set(showDistributionDetails)
     }
 }

--- a/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerExtensionProperties.groovy
+++ b/src/main/groovy/com/adarshr/gradle/testlogger/TestLoggerExtensionProperties.groovy
@@ -89,4 +89,9 @@ abstract class TestLoggerExtensionProperties {
      * Whether only slow tests should be shown. Defaults to false.
      */
     Boolean showOnlySlow
+
+    /**
+     * Whether test distribution details (e.g., partition and session info) should be shown. Defaults to true.
+     */
+    Boolean showDistributionDetails
 }

--- a/src/test/groovy/com/adarshr/gradle/testlogger/TestDescriptorWrapperSpec.groovy
+++ b/src/test/groovy/com/adarshr/gradle/testlogger/TestDescriptorWrapperSpec.groovy
@@ -73,4 +73,41 @@ class TestDescriptorWrapperSpec extends Specification {
             'com.adarshr.Test$One$Two' | 'Two'             | 'Two'
             'com.adarshr.Test$One$Two' | 'Bar'             | 'Bar'
     }
+
+    def "trail includes all ancestors when showDistributionDetails is true"() {
+        given:
+            testLoggerExtensionMock.showDistributionDetails >> true
+            wrapper = new TestDescriptorWrapper(testDescriptorMock, testLoggerExtensionMock, [
+                Mock(TestDescriptorWrapper) { displayName >> 'Distributed Test Run :test' },
+                Mock(TestDescriptorWrapper) { displayName >> 'Partition 1 in session 2 on uuid' },
+                Mock(TestDescriptorWrapper) { displayName >> 'SuspendTest' },
+            ])
+        expect:
+            wrapper.trail == 'Distributed Test Run :test > Partition 1 in session 2 on uuid > SuspendTest'
+    }
+
+    def "trail filters distribution ancestors when showDistributionDetails is false"() {
+        given:
+            testLoggerExtensionMock.showDistributionDetails >> false
+            wrapper = new TestDescriptorWrapper(testDescriptorMock, testLoggerExtensionMock, [
+                Mock(TestDescriptorWrapper) { displayName >> 'Distributed Test Run :test' },
+                Mock(TestDescriptorWrapper) { displayName >> 'Partition 1 in session 2 on uuid' },
+                Mock(TestDescriptorWrapper) { displayName >> 'SuspendTest' },
+            ])
+        expect:
+            wrapper.trail == 'SuspendTest'
+    }
+
+    def "trail filters only distribution-related ancestors when showDistributionDetails is false"() {
+        given:
+            testLoggerExtensionMock.showDistributionDetails >> false
+            wrapper = new TestDescriptorWrapper(testDescriptorMock, testLoggerExtensionMock, [
+                Mock(TestDescriptorWrapper) { displayName >> 'Distributed Test Run :test' },
+                Mock(TestDescriptorWrapper) { displayName >> 'Partition 1 in session 2 on uuid' },
+                Mock(TestDescriptorWrapper) { displayName >> ':test' },
+                Mock(TestDescriptorWrapper) { displayName >> 'SuspendTest' },
+            ])
+        expect:
+            wrapper.trail == ':test > SuspendTest'
+    }
 }


### PR DESCRIPTION
When Develocity Test distribution is enabled, and a parallel theme is chosen, the test names are too long. This can get unreadable.

This change allows requesting shorter names. The default behavior is same as before.

<details>
<summary>Non-parallel</summary>

<img width="761" height="317" alt="image" src="https://github.com/user-attachments/assets/79ba1382-5f1d-46d2-988b-07868b9843be" />


</details>

<details>
<summary>Parallel with `showDistributionDetails = false`</summary>

<img width="786" height="157" alt="image" src="https://github.com/user-attachments/assets/b21c27b8-f6ee-4331-9a39-e272696dfd5f" />

</details>

<details>
<summary>Parallel with `showDistributionDetails = true` or skipped</summary>

<img width="1090" height="147" alt="image" src="https://github.com/user-attachments/assets/753f69aa-a8a0-4d01-acdb-c42345c38ae6" />


</details>

Refs: #340